### PR TITLE
jailbreak root detection package changed

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -24,7 +24,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace "com.example.example"
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdkVersion 35
     ndkVersion flutter.ndkVersion
 
     compileOptions {
@@ -46,7 +46,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdkVersion 21
-        targetSdkVersion flutter.targetSdkVersion
+        targetSdkVersion 35
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -30,8 +30,8 @@
             android:name="flutterEmbedding"
             android:value="2" />
         <activity
-    android:name="com.yalantis.ucrop.UCropActivity"
-    android:screenOrientation="portrait"
-    android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
+            android:name="com.yalantis.ucrop.UCropActivity"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
     </application>
 </manifest>

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,20 +1,8 @@
-buildscript {
-    ext.kotlin_version = '1.7.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url "https://jitpack.io" }
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -5,16 +5,21 @@ pluginManagement {
         def flutterSdkPath = properties.getProperty("flutter.sdk")
         assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
         return flutterSdkPath
-    }
-    settings.ext.flutterSdkPath = flutterSdkPath()
+    }()
 
-    includeBuild("${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle")
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-    plugins {
-        id "dev.flutter.flutter-gradle-plugin" version "1.0.0" apply false
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
     }
 }
 
-include ":app"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.1.1" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.0" apply false
+}
 
-apply from: "${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+include ":app"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -22,6 +22,9 @@ dev_dependencies:
 
   flutter_lints: ^2.0.0
 
+dependency_overrides:
+  macos_ui: 2.1.3
+
 # The following section is specific to Flutter packages.
 flutter:
 

--- a/lib/src/root_device_helper.dart
+++ b/lib/src/root_device_helper.dart
@@ -1,7 +1,7 @@
 // Package imports:
 
 // Package imports:
-import 'package:flutter_jailbreak_detection/flutter_jailbreak_detection.dart';
+import 'package:jailbreak_root_detection/jailbreak_root_detection.dart';
 
 // Project imports:
 import '../master_utility.dart';
@@ -12,7 +12,7 @@ class RootDeviceHelper {
     bool jailBroken = false;
 
     try {
-      jailBroken = await FlutterJailbreakDetection.jailbroken;
+      jailBroken = await JailbreakRootDetection.instance.isJailBroken;
     } catch (e) {
       jailBroken = true;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,6 @@ dependencies:
   dio: ^5.7.0
   dio_http_formatter: ^3.3.0
   shared_preferences: ^2.3.2
-  flutter_jailbreak_detection: ^1.10.0
   import_sorter: ^4.6.0
   flutter_cache_manager: ^3.3.1
   image_picker_platform_interface: ^2.9.4
@@ -29,6 +28,7 @@ dependencies:
   permission_handler: ^11.3.0
   device_info_plus: ^10.0.1
   pointycastle: ^3.9.1
+  jailbreak_root_detection: ^1.1.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Replace `flutter_jailbreak_detection: ^1.10.0` with  `jailbreak_root_detection: ^1.1.5`
- migrate example app with gradle version 8
- Remove deprecated methods from setting.gradle and update it.