### PR TITLE
Mix panel event track improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.21
+
+- API helper: Dynamic Mixpanel payloads via successDataBuilder / errorDataBuilder on MixPanelEventModel, used by APIService when tracking API success and failure paths.
+
+
 ## 0.0.20
 
 - Added custom error mapper in API configurations.

--- a/lib/src/api_helper/api_service.dart
+++ b/lib/src/api_helper/api_service.dart
@@ -83,19 +83,18 @@ class APIService {
     FormData? formData,
   }) async {
     try {
-      final Response<dynamic>? response =
-          await _getResponse(request: request, formData: formData);
+      final Response<dynamic>? response = await _getResponse(request: request, formData: formData);
 
       if (response != null) {
         if (request.mixPanelEventModel != null) {
+          final successData = request.mixPanelEventModel?.successData;
+          final successDataBuilder = request.mixPanelEventModel?.successDataBuilder?.call(response);
           MixPanelService.instance.trackEvent(
-            eventName: request.mixPanelEventModel?.eventName ??
-                _removeQueryParams(request.url),
-            data: request.mixPanelEventModel?.successData,
+            eventName: request.mixPanelEventModel?.eventName ?? _removeQueryParams(request.url),
+            data: successData ?? successDataBuilder,
           );
         }
-        if (request.mixPanelEventModel == null &&
-            request.enableMixpanelTracking == true) {
+        if (request.mixPanelEventModel == null && request.enableMixpanelTracking == true) {
           MixPanelService.instance.trackEvent(
             eventName: _removeQueryParams(request.url),
             data: response.data,
@@ -111,14 +110,14 @@ class APIService {
       );
     } on DioException catch (e) {
       if (request.mixPanelEventModel != null) {
+        final errorData = request.mixPanelEventModel?.errorData;
+        final errorDataBuilder = request.mixPanelEventModel?.errorDataBuilder?.call(e.response, e, e.stackTrace);
         MixPanelService.instance.trackEvent(
-          eventName: request.mixPanelEventModel?.eventName ??
-              _removeQueryParams(request.url),
-          data: request.mixPanelEventModel?.errorData,
+          eventName: request.mixPanelEventModel?.eventName ?? _removeQueryParams(request.url),
+          data: errorData ?? errorDataBuilder,
         );
       }
-      if (request.mixPanelEventModel == null &&
-          request.enableMixpanelTracking == true) {
+      if (request.mixPanelEventModel == null && request.enableMixpanelTracking == true) {
         MixPanelService.instance.trackEvent(
           eventName: _removeQueryParams(request.url),
           data: e.response?.data,
@@ -128,8 +127,7 @@ class APIService {
         final APIResponse<dynamic> errorModel;
         if (e.response?.statusCode == 422) {
           if (e.response?.data['detail']?.isNotEmpty ?? false) {
-            ApiErrorModel errorResponse =
-                ApiErrorModel.fromJson(e.response?.data);
+            ApiErrorModel errorResponse = ApiErrorModel.fromJson(e.response?.data);
             String errorMessage = setErrorData(errorResponse.detail);
 
             debugPrint(errorMessage);
@@ -182,18 +180,17 @@ class APIService {
 
         return errorModel;
       }
-      return APIResponse<dynamic>.custom(
-          message: ErrorHandler.instance.getDioError(e));
+      return APIResponse<dynamic>.custom(message: ErrorHandler.instance.getDioError(e));
     } catch (e) {
       if (request.mixPanelEventModel != null) {
+        final errorData = request.mixPanelEventModel?.errorData;
+        final errorDataBuilder = request.mixPanelEventModel?.errorDataBuilder?.call(null);
         MixPanelService.instance.trackEvent(
-          eventName: request.mixPanelEventModel?.eventName ??
-              _removeQueryParams(request.url),
-          data: request.mixPanelEventModel?.errorData,
+          eventName: request.mixPanelEventModel?.eventName ?? _removeQueryParams(request.url),
+          data: errorData ?? errorDataBuilder,
         );
       }
-      if (request.mixPanelEventModel == null &&
-          request.enableMixpanelTracking == true) {
+      if (request.mixPanelEventModel == null && request.enableMixpanelTracking == true) {
         MixPanelService.instance.trackEvent(
           eventName: _removeQueryParams(request.url),
         );
@@ -243,22 +240,20 @@ class APIService {
     /// Use this for if response is JsonArray
     final ListJsonMapper<T>? listJsonMapper,
   }) async {
-    assert(jsonMapper == null || listJsonMapper == null,
-        'Can not provide both json mapper!');
+    assert(jsonMapper == null || listJsonMapper == null, 'Can not provide both json mapper!');
     try {
-      final Response<dynamic>? response =
-          await _getResponse(request: request, formData: formData);
+      final Response<dynamic>? response = await _getResponse(request: request, formData: formData);
 
       if (response != null) {
         if (request.mixPanelEventModel != null) {
+          final successData = request.mixPanelEventModel?.successData;
+          final successDataBuilder = request.mixPanelEventModel?.successDataBuilder?.call(response);
           MixPanelService.instance.trackEvent(
-            eventName: request.mixPanelEventModel?.eventName ??
-                _removeQueryParams(request.url),
-            data: request.mixPanelEventModel?.successData,
+            eventName: request.mixPanelEventModel?.eventName ?? _removeQueryParams(request.url),
+            data: successData ?? successDataBuilder,
           );
         }
-        if (request.mixPanelEventModel == null &&
-            request.enableMixpanelTracking == true) {
+        if (request.mixPanelEventModel == null && request.enableMixpanelTracking == true) {
           MixPanelService.instance.trackEvent(
             eventName: _removeQueryParams(request.url),
             data: response.data,
@@ -266,12 +261,10 @@ class APIService {
         }
 
         if (response.data is Map<String, dynamic> && jsonMapper != null) {
-          final data =
-              await compute(jsonMapper, response.data as Map<String, dynamic>);
+          final data = await compute(jsonMapper, response.data as Map<String, dynamic>);
           return right(data);
         } else if (response.data is List<dynamic> && listJsonMapper != null) {
-          final data =
-              await compute(listJsonMapper, response.data as List<dynamic>);
+          final data = await compute(listJsonMapper, response.data as List<dynamic>);
 
           return right(data);
         }
@@ -281,14 +274,14 @@ class APIService {
       return left(ApiException(message: APIConstError.kSomethingWentWrong));
     } on DioException catch (e) {
       if (request.mixPanelEventModel != null) {
+        final errorData = request.mixPanelEventModel?.errorData;
+        final errorDataBuilder = request.mixPanelEventModel?.errorDataBuilder?.call(e.response, e, e.stackTrace);
         MixPanelService.instance.trackEvent(
-          eventName: request.mixPanelEventModel?.eventName ??
-              _removeQueryParams(request.url),
-          data: request.mixPanelEventModel?.errorData,
+          eventName: request.mixPanelEventModel?.eventName ?? _removeQueryParams(request.url),
+          data: errorData ?? errorDataBuilder,
         );
       }
-      if (request.mixPanelEventModel == null &&
-          request.enableMixpanelTracking == true) {
+      if (request.mixPanelEventModel == null && request.enableMixpanelTracking == true) {
         MixPanelService.instance.trackEvent(
           eventName: _removeQueryParams(request.url),
           data: e.response?.data,
@@ -300,8 +293,7 @@ class APIService {
 
         if (e.response?.statusCode == 422) {
           if (e.response?.data['detail']?.isNotEmpty ?? false) {
-            ApiErrorModel errorResponse =
-                ApiErrorModel.fromJson(e.response?.data);
+            ApiErrorModel errorResponse = ApiErrorModel.fromJson(e.response?.data);
             String errorMessage = setErrorData(errorResponse.detail);
 
             debugPrint(errorMessage);
@@ -359,16 +351,15 @@ class APIService {
       );
     } catch (e, stackTrace) {
       if (request.mixPanelEventModel != null) {
+        final errorData = request.mixPanelEventModel?.errorData;
+        final errorDataBuilder = request.mixPanelEventModel?.errorDataBuilder?.call(null, null, stackTrace);
         MixPanelService.instance.trackEvent(
-          eventName: request.mixPanelEventModel?.eventName ??
-              _removeQueryParams(request.url),
-          data: request.mixPanelEventModel?.errorData,
+          eventName: request.mixPanelEventModel?.eventName ?? _removeQueryParams(request.url),
+          data: errorData ?? errorDataBuilder,
         );
       }
-      if (request.mixPanelEventModel == null &&
-          request.enableMixpanelTracking == true) {
-        MixPanelService.instance
-            .trackEvent(eventName: _removeQueryParams(request.url));
+      if (request.mixPanelEventModel == null && request.enableMixpanelTracking == true) {
+        MixPanelService.instance.trackEvent(eventName: _removeQueryParams(request.url));
       }
       return left(
         ApiException(

--- a/lib/src/api_helper/mix_panel_event_model.dart
+++ b/lib/src/api_helper/mix_panel_event_model.dart
@@ -1,18 +1,33 @@
+import 'package:master_utility/master_utility.dart';
+
 class MixPanelEventModel {
   String? eventName;
   Map<String, dynamic>? successData;
   Map<String, dynamic>? errorData;
 
-  MixPanelEventModel({this.eventName, this.successData, this.errorData});
+  Map<String, dynamic>? Function([Response<dynamic>? response, Exception? exception, StackTrace? stackTrace])?
+      errorDataBuilder;
+  Map<String, dynamic>? Function(Response<dynamic>? response)? successDataBuilder;
+
+  MixPanelEventModel({
+    this.eventName,
+    this.successData,
+    this.errorData,
+    this.errorDataBuilder,
+    this.successDataBuilder,
+  });
 
   MixPanelEventModel.fromJson(Map<String, dynamic> json) {
     eventName = json['eventName'];
-    successData = json['successData'] != null
-        ? Map<String, dynamic>.from(json['successData'])
+    successData = json['successData'] != null ? Map<String, dynamic>.from(json['successData']) : null;
+    errorData = json['errorData'] != null ? Map<String, dynamic>.from(json['errorData']) : null;
+
+    errorDataBuilder = json['errorDataBuilder'] != null
+        ? ([Response<dynamic>? response, Exception? exception, StackTrace? stackTrace]) =>
+            Map<String, dynamic>.from(json['errorDataBuilder'])
         : null;
-    errorData = json['errorData'] != null
-        ? Map<String, dynamic>.from(json['errorData'])
-        : null;
+    successDataBuilder =
+        json['successDataBuilder'] != null ? (response) => Map<String, dynamic>.from(json['successDataBuilder']) : null;
   }
 
   Map<String, dynamic> toJson() {
@@ -23,6 +38,13 @@ class MixPanelEventModel {
     }
     if (errorData != null) {
       data['errorData'] = errorData;
+    }
+
+    if (errorDataBuilder != null) {
+      data['errorDataBuilder'] = errorDataBuilder;
+    }
+    if (successDataBuilder != null) {
+      data['successDataBuilder'] = successDataBuilder;
     }
     return data;
   }

--- a/lib/src/api_helper/mix_panel_event_model.dart
+++ b/lib/src/api_helper/mix_panel_event_model.dart
@@ -11,8 +11,8 @@ class MixPanelEventModel {
 
   MixPanelEventModel({
     this.eventName,
-    this.successData,
-    this.errorData,
+    @Deprecated('Use successDataBuilder instead of successData that will be removed in the future') this.successData,
+    @Deprecated('Use errorDataBuilder instead of errorData that will be removed in the future') this.errorData,
     this.errorDataBuilder,
     this.successDataBuilder,
   });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: master_utility
 description: All-in-one utility solution with Size, Navigation, Image Picker,
   Date Time, Auto Size Text, Toast, Email, Log, Dialog, Cache Image, Validation,
   API and Shared Preferences.
-version: 0.0.20
+version: 0.0.21
 homepage: https://github.com/webelightsolutions/flutter-master-utility.git
 repository: https://github.com/webelightsolutions/flutter-master-utility.git
 issue_tracker: https://github.com/webelightsolutions/flutter-master-utility/issues


### PR DESCRIPTION
Update CHANGELOG for version 0.0.21, introducing dynamic Mixpanel payloads via successDataBuilder and errorDataBuilder in MixPanelEventModel. Deprecate old successData and errorData fields. Update pubspec.yaml to reflect new version.

